### PR TITLE
fix: remove stray backtick in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,3 @@ RUN chmod +x deploy/entrypoint.sh
 EXPOSE 8000
 
 CMD ["deploy/entrypoint.sh"]
-`


### PR DESCRIPTION
## Summary
- `Dockerfile` 마지막 줄 불필요한 백틱(`) 제거

## Test plan
- [ ] `docker compose up -d --build` 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)