### PR TITLE
#4 [feat] : GitHub Actions 자동 배포 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy to GCP
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.GCP_HOST }}
+          username: ${{ secrets.GCP_USER }}
+          key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          script: |
+            cd ~/linkdbot-rag
+            git pull origin main
+            docker compose up -d --build


### PR DESCRIPTION
## Summary
- GitHub Actions workflow 추가 (`deploy.yml`)
- `main` 브랜치 푸시 시 GCP VM에 자동으로 SSH 접속 후 배포

## 배포 흐름
`main` 머지 → GitHub Actions 트리거 → GCP SSH → `git pull` + `docker compose up -d --build`

## 사전 설정 (완료)
- [x] GCP SSH 키 생성 및 `authorized_keys` 등록
- [x] GitHub Secrets 등록 (`GCP_HOST`, `GCP_USER`, `GCP_SSH_PRIVATE_KEY`)

## Test plan
- [ ] main 머지 후 Actions 탭에서 워크플로우 성공 확인
- [ ] GCP에서 최신 코드 반영 확인

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)