### PR TITLE
[FEAT/#30] Notion 알림 개선 — DB URL 반환 및 인라인 버튼 적용

### DIFF
--- a/app/infrastructure/external/telegram_client.py
+++ b/app/infrastructure/external/telegram_client.py
@@ -39,6 +39,18 @@ class TelegramClient:
                 },
             )
 
+    async def send_link_saved_message(
+        self, chat_id: int, text: str, notion_url: str | None = None
+    ) -> None:
+        """링크 저장 완료 메시지 전송. notion_url이 있으면 인라인 버튼으로 추가."""
+        payload: dict = {"chat_id": chat_id, "text": text, "parse_mode": "HTML"}
+        if notion_url:
+            payload["reply_markup"] = {
+                "inline_keyboard": [[{"text": "📓 Notion에서 보기", "url": notion_url}]]
+            }
+        async with httpx.AsyncClient() as client:
+            await client.post(f"{self._base}/sendMessage", json=payload)
+
     async def answer_callback_query(self, callback_query_id: str) -> None:
         """콜백 버튼 로딩 스피너 해제."""
         async with httpx.AsyncClient() as client:

--- a/app/services/link_service.py
+++ b/app/services/link_service.py
@@ -83,9 +83,10 @@ class LinkService:
             )
 
             # 7. 완료 알림
-            await self._telegram.send_message(
-                telegram_id,
-                _build_done_message(title, category, keywords, summary, notion_url),
+            await self._telegram.send_link_saved_message(
+                chat_id=telegram_id,
+                text=_build_done_message(title, category, keywords, summary),
+                notion_url=notion_url or None,
             )
 
         except Exception as exc:
@@ -99,14 +100,10 @@ def _build_done_message(
     category: str,
     keywords: list[str],
     summary: str,
-    notion_url: str,
 ) -> str:
-    msg = (
+    return (
         f"✅ 저장 완료!\n\n"
         f"📌 <b>{title}</b>\n"
         f"📂 {category}  |  🔑 {', '.join(keywords)}\n\n"
         f"📝 {summary}"
     )
-    if notion_url:
-        msg += f"\n\n📓 Notion: {notion_url}"
-    return msg

--- a/app/services/notion_service.py
+++ b/app/services/notion_service.py
@@ -23,7 +23,7 @@ class NotionService:
         if not token or not user or not user.notion_database_id:
             return ""
         try:
-            return await self._notion.create_database_entry(
+            await self._notion.create_database_entry(
                 access_token=token,
                 database_id=user.notion_database_id,
                 title=title,
@@ -33,6 +33,8 @@ class NotionService:
                 url=url,
                 memo=memo,
             )
+            db_id = user.notion_database_id.replace("-", "")
+            return f"https://www.notion.so/{db_id}"
         except Exception:
             return ""
 


### PR DESCRIPTION
## Summary

- `NotionService.save()`: 개별 페이지 URL 대신 부모 데이터베이스 URL 반환
- `TelegramClient.send_link_saved_message()` 신규 추가 — Notion URL을 텍스트 노출 없이 인라인 버튼으로 전송
- `LinkService.process_link()`: 완료 알림을 `send_link_saved_message`로 전환, `_build_done_message`에서 URL 파라미터 제거

## Test plan

- [ ] 링크 전송 후 완료 메시지에 `📓 Notion에서 보기` 버튼이 표시되는지 확인
- [ ] 버튼 클릭 시 Notion DB 페이지(개별 항목이 아닌 DB)로 이동하는지 확인
- [ ] Notion 미연동 유저는 버튼 없이 텍스트 메시지만 수신하는지 확인

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * When links are saved, users now receive notifications with an inline button to quickly view saved links directly in Notion.

* **Refactor**
  * Improved the notification system to support richer message formatting and interactive elements for enhanced user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->