### PR TITLE
[fix/#60] config.py ENV production guard 롤백

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,7 +1,4 @@
-from pydantic import model_validator
 from pydantic_settings import BaseSettings
-
-_DEV_SECRET = "dev-insecure-dashboard-secret"
 
 
 class Settings(BaseSettings):
@@ -15,20 +12,10 @@ class Settings(BaseSettings):
     ENCRYPTION_KEY: str  # Fernet key
     JINA_API_KEY: str | None = None
     TELEGRAM_TEST_ID: int | None = None
-    ENV: str = "development"  # "production" in prod .env
-    DASHBOARD_JWT_SECRET: str = _DEV_SECRET
+    DASHBOARD_JWT_SECRET: str = "dev-insecure-dashboard-secret"  # override in prod via .env
     DASHBOARD_URL: str = "http://localhost:8501"
 
     model_config = {"env_file": ".env", "extra": "ignore"}
-
-    @model_validator(mode="after")
-    def _check_secret_in_prod(self) -> "Settings":
-        if self.ENV == "production" and self.DASHBOARD_JWT_SECRET == _DEV_SECRET:
-            raise ValueError(
-                "DASHBOARD_JWT_SECRET must be explicitly set in production. "
-                "Set ENV=production in .env only after configuring a strong secret."
-            )
-        return self
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- PR #59 머지 후 `ca63dd1` 커밋(ENV guard 롤백)이 main에 누락됨
- 배포된 `config.py`에 `model_validator`가 남아있어 `ENV=production` + 기본 secret 조합 시 서버 시작 실패
- `config.py`를 깔끔한 버전으로 복구 (ENV 필드 및 validator 제거)

## Changes
- `app/core/config.py`: `ENV` 필드 및 `_check_secret_in_prod` validator 제거

## Test plan
- [ ] 서버 정상 시작 확인 (`uvicorn app.main:app --reload`)
- [ ] GCP 배포 후 `/dashboard` 명령어 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified configuration validation by removing production-time secret enforcement.
  * Updated default JWT secret to a placeholder value; production deployments must override via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->