### PR TITLE
[fix/#63] nginx-dashboard.conf HTTP only로 수정 (certbot 자동 SSL)

### DIFF
--- a/deploy/nginx-dashboard.conf
+++ b/deploy/nginx-dashboard.conf
@@ -1,15 +1,6 @@
 server {
     listen 80;
     server_name linkdbot-dashboard.chanu.shop;
-    return 301 https://$host$request_uri;
-}
-
-server {
-    listen 443 ssl;
-    server_name linkdbot-dashboard.chanu.shop;
-
-    ssl_certificate /etc/letsencrypt/live/linkdbot-dashboard.chanu.shop/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/linkdbot-dashboard.chanu.shop/privkey.pem;
 
     location / {
         proxy_pass http://localhost:8501;


### PR DESCRIPTION
## Summary
- SSL 블록 제거 → certbot 실행 시 자동으로 추가됨
- 초기 설정 절차와 일치하도록 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Removed HTTPS/SSL termination configuration. The application now operates on HTTP port 80 only, proxying requests to localhost:8501 with WebSocket support enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->