### PR TITLE
[FIX/#91] title 매칭 추가 및 FTS 점수 보존으로 검색 랭킹 개선

### DIFF
--- a/app/infrastructure/rag/retriever.py
+++ b/app/infrastructure/rag/retriever.py
@@ -83,7 +83,7 @@ def _token_matches(query_token: str, keyword: str) -> bool:
 
 
 def _rescore_with_keywords(results: list[dict], query: str) -> list[dict]:
-    """dense_score + keyword overlap으로 final_score 재산출 후 내림차순 정렬.
+    """DB similarity(base) + keyword/title overlap으로 final_score 재산출 후 내림차순 정렬.
 
     query 변형(원문/공백제거/bi-gram)별 overlap 중 최댓값을 사용.
     """
@@ -96,7 +96,6 @@ def _rescore_with_keywords(results: list[dict], query: str) -> list[dict]:
 
     rescored = []
     for r in results:
-        dense_score = r.get("dense_score", r.get("similarity", 0))
         keyword_weight = (
             _KEYWORD_WEIGHT_JINA if r.get("content_source") == "jina"
             else _KEYWORD_WEIGHT_OG

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -12,13 +12,13 @@ def make_retriever():
     return HybridRetriever(openai=openai, chunk_repo=chunk_repo), chunk_repo
 
 
-def _make_result(link_id, title, keywords, dense_score, content_source="jina"):
+def _make_result(link_id, title, keywords, dense_score, content_source="jina", similarity=None):
     return {
         "link_id": link_id,
         "title": title,
         "keywords": json.dumps(keywords),
         "dense_score": dense_score,
-        "similarity": dense_score,
+        "similarity": dense_score * 0.7 if similarity is None else similarity,
         "content_source": content_source,
         "url": f"https://example.com/{link_id}",
         "summary": "",
@@ -46,7 +46,14 @@ async def test_og_source_has_lower_keyword_weight():
     """content_source='og'인 경우 keyword_weight가 0.1로 낮아야 한다."""
     retriever, chunk_repo = make_retriever()
     chunk_repo.search_similar.return_value = [
-        _make_result(1, "테스트", ["하나증권", "채용"], dense_score=0.5, content_source="og"),
+        _make_result(
+            1,
+            "테스트",
+            ["하나증권", "채용"],
+            dense_score=0.5,
+            content_source="og",
+            similarity=0.5,
+        ),
     ]
 
     results = await retriever.retrieve(user_id=111, query="하나증권 채용", top_k=5)
@@ -60,7 +67,14 @@ async def test_jina_source_has_higher_keyword_weight():
     """content_source='jina'인 경우 keyword_weight가 0.3이어야 한다."""
     retriever, chunk_repo = make_retriever()
     chunk_repo.search_similar.return_value = [
-        _make_result(1, "테스트", ["하나증권", "채용"], dense_score=0.5, content_source="jina"),
+        _make_result(
+            1,
+            "테스트",
+            ["하나증권", "채용"],
+            dense_score=0.5,
+            content_source="jina",
+            similarity=0.5,
+        ),
     ]
 
     results = await retriever.retrieve(user_id=111, query="하나증권 채용", top_k=5)
@@ -145,9 +159,9 @@ async def test_same_link_deduped():
     """같은 link_id의 여러 chunk가 결과에 1개만 남아야 한다."""
     retriever, chunk_repo = make_retriever()
     chunk_repo.search_similar.return_value = [
-        _make_result(1, "하나증권 공고", ["하나증권", "채용공고"], dense_score=0.80),
-        _make_result(1, "하나증권 공고", ["하나증권", "채용공고"], dense_score=0.75),
-        _make_result(2, "파이썬 로깅", ["Python", "로깅"], dense_score=0.80),
+        _make_result(1, "하나증권 공고", ["하나증권", "채용공고"], dense_score=0.80, similarity=0.80),
+        _make_result(1, "하나증권 공고", ["하나증권", "채용공고"], dense_score=0.75, similarity=0.75),
+        _make_result(2, "파이썬 로깅", ["Python", "로깅"], dense_score=0.80, similarity=0.80),
     ]
 
     results = await retriever.retrieve(user_id=111, query="하나증권", top_k=5)


### PR DESCRIPTION
## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
closed #91

## 📝 𝗦𝘂𝗺𝗺𝗮𝗿𝘆
> 변경 사항을 간략히 설명해주세요.

- retriever 재스코어에서 `keywords` 외 `title`도 토큰 매칭 소스로 반영
- 최종 점수 base를 `dense_score`가 아닌 DB `similarity`(dense+sparse/FTS) 우선으로 변경하여 FTS 신호 보존
- 회귀 테스트 3개 추가:
  - title 매칭으로 엔티티 포함 문서 우선 노출
  - keywords 누락(None)이어도 title 매칭 동작
  - DB FTS boost가 reranking에서도 유지

## 📈 𝗥𝗮𝗻𝗸𝗶𝗻𝗴 𝗤𝘂𝗮𝗹𝗶𝘁𝘆 𝗠𝗲𝗮𝘀𝘂𝗿𝗲𝗺𝗲𝗻𝘁 (Before vs After)

측정 방식:
- 동일한 5개 시나리오에 대해 **구버전 스코어링 함수(before)** 와 **현재 코드(after)** 를 각각 적용
- 지표: **P@1**, **MRR** (랭킹 상위 정확도 중심)

| 시나리오 | Before Top1 | After Top1 | P@1 Before→After | MRR Before→After |
|---|---:|---:|---:|---:|
| 롯데 title-only 엔터티 | 2 | 2 | 0.00 → 0.00 | 0.50 → 0.50 |
| keywords 없음 + title 매칭 | 2 | 1 | 0.00 → 1.00 | 0.50 → 1.00 |
| FTS boost 보존 | 2 | 1 | 0.00 → 1.00 | 0.50 → 1.00 |
| 기존 키워드 강매칭 유지 | 1 | 1 | 1.00 → 1.00 | 1.00 → 1.00 |
| 비동기 검색 정밀도 유지 | 1 | 1 | 1.00 → 1.00 | 1.00 → 1.00 |
| **평균(5개)** | - | - | **0.40 → 0.80** | **0.70 → 0.90** |

해석:
- 이번 변경으로 **title-only 매칭 누락**, **FTS 신호 소실** 유형의 오답이 개선됨
- 다만 `롯데 채용 공고`처럼 dense 격차가 큰 케이스는 title 매칭만으로는 역전이 어려울 수 있음(추가 가중치 정책은 후속 검토)

## 🧪 𝗧𝗲𝘀𝘁
> 이 PR을 로컬에서 테스트하려면 다음을 실행하세요:
```bash
# 마이그레이션 적용 (변경 사항이 있을 경우)
alembic upgrade head

# 개발 서버 실행
uvicorn app.main:app --reload --port 8000

# 테스트 실행
pytest
```

> **필수 테스트:**
- [ ] 웹훅 엔드포인트: `POST /api/v1/webhook/telegram` (tests/test_webhook.http 참고)
- [ ] `/start`, `/memo`, `/search`, `/ask` 명령어 정상 작동
- [ ] URL 저장 정상 작동
- [x] `PYTHONDONTWRITEBYTECODE=1 ~/.local/bin/uv run --with-requirements requirements.txt python -m pytest -q tests/test_retriever.py` (20 passed)

## 📸 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 검색 랭킹 로직 개선 | N/A |

## 💡 𝗥𝗲𝗳𝗲𝗿𝗲𝗻𝗰𝗲
- 이슈 재현 문맥: "롯데 채용 공고" 검색 시 비의도 상위 랭킹