### PR TITLE
[FIX/#94] deploy: command_timeout 30m, docker image prune으로 build cache 보존

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,10 +28,11 @@ jobs:
           username: ${{ secrets.GCP_USER }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           port: 22
+          command_timeout: 30m
           script: |
             cd ~/linkdbot-rag
             git fetch origin
             git checkout -B main origin/main
-            docker system prune -f
+            docker image prune -f
             docker compose up -d --build
             docker compose exec -T app alembic upgrade head


### PR DESCRIPTION
## Summary
- `command_timeout: 10m(기본값)` → `30m` 으로 증가
- `docker system prune -f` → `docker image prune -f` 로 교체

## 원인
kiwipiepy_model(79.5MB) 첫 빌드 + docker 레이어 export(~336s×2)로 기본 타임아웃 10분 초과

## 효과
- 이번 배포: 30m 내 완료
- 이후 배포: pip install 레이어 캐시 재사용 → 빠른 빌드

## Test plan
- [x] deploy.yml 문법 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal deployment configuration improvements to optimize build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->