### PR TITLE
[FIX/#94] deploy: remove blocking alembic exec, non-blocking migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,4 +35,3 @@ jobs:
             git checkout -B main origin/main
             docker image prune -f
             docker compose up -d --build
-            docker compose exec -T app alembic upgrade head

--- a/alembic/versions/0006_rebuild_tsvectors_with_morpheme_tokenization.py
+++ b/alembic/versions/0006_rebuild_tsvectors_with_morpheme_tokenization.py
@@ -1,30 +1,25 @@
-"""Phase B: Rebuild chunk tsvectors with kiwipiepy morpheme tokenization.
+"""Phase B: version marker for morpheme tokenization tsvector rebuild.
 
 Revision ID: phase_b_0006
 Revises: phase3_0005
 Create Date: 2026-03-15
 
-WHY THIS MIGRATION EXISTS:
-  Phase A stored tsvectors using to_tsvector('simple', raw_content).
-  Korean compound words like '채용공고' became single unsplit tokens,
-  so FTS queries for '채용' or '공고' produced sparse_score ≈ 0.
+NOTE: This migration contains no schema changes (DDL).
+The tsv column and GIN index were added in phase3_0005.
 
-  Phase B uses kiwipiepy to pre-split compound words into morphemes before
-  passing to PostgreSQL.  This migration backfills all existing chunks so
-  their tsv column reflects morpheme-split tokens.
+Data backfill (rebuilding tsvectors with kiwipiepy) is handled by a
+separate script to avoid blocking app startup:
 
-  EFFECT:
-    Before: to_tsvector('simple', '채용공고 안내') → {'채용공고', '안내'}
-    After:  to_tsvector('simple', '채용 공고 안내') → {'채용', '공고', '안내'}
-    Queries for '채용' or '공고' now hit the GIN index → sparse_score > 0.
+    python scripts/backfill_morpheme_tsvectors.py
+
+On fresh installations there are no existing chunks, so backfill is
+unnecessary — new chunks are tokenized at insert time via
+chunk_repository.save_chunks().
 """
 
 from __future__ import annotations
 
 from typing import Sequence, Union
-
-import sqlalchemy as sa
-from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "phase_b_0006"
@@ -32,96 +27,10 @@ down_revision: Union[str, None] = "phase3_0005"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-_BATCH_SIZE = 500
-
-
-def _make_kiwi():
-    """Initialize Kiwi once per migration run.
-
-    Raises ImportError explicitly if kiwipiepy is not installed so the
-    migration fails loudly rather than silently backfilling raw text.
-    """
-    try:
-        from kiwipiepy import Kiwi  # type: ignore[import]
-    except ImportError:
-        raise ImportError(
-            "kiwipiepy is required for this migration. "
-            "Run: pip install kiwipiepy"
-        )
-    return Kiwi()
-
-
-def _tokenize(kiwi, text: str) -> str:
-    tokens = kiwi.tokenize(text)
-    return " ".join(
-        t.form for t in tokens
-        if t.tag.startswith(("NN", "VV", "SL", "XR"))
-    )
-
 
 def upgrade() -> None:
-    """Rebuild all existing chunk tsvectors with morpheme tokenization.
-
-    Uses cursor-based pagination (WHERE id > last_id) and batch executemany
-    to avoid LIMIT/OFFSET scan degradation and per-row roundtrips.
-    Kiwi is initialized once for the entire migration run.
-    """
-    kiwi = _make_kiwi()
-    conn = op.get_bind()
-
-    last_id = 0
-    while True:
-        rows = conn.execute(
-            sa.text(
-                "SELECT id, content FROM chunks "
-                "WHERE id > :last_id ORDER BY id LIMIT :lim"
-            ),
-            {"last_id": last_id, "lim": _BATCH_SIZE},
-        ).fetchall()
-
-        if not rows:
-            break
-
-        params = [
-            {"mc": _tokenize(kiwi, row.content or ""), "id": row.id}
-            for row in rows
-        ]
-        conn.execute(
-            sa.text("UPDATE chunks SET tsv = to_tsvector('simple', :mc) WHERE id = :id"),
-            params,
-        )
-
-        last_id = rows[-1].id
-
-    conn.execute(sa.text("ANALYZE chunks"))
+    pass  # Data backfill handled by scripts/backfill_morpheme_tsvectors.py
 
 
 def downgrade() -> None:
-    """Revert tsvectors to raw content (Phase A behaviour)."""
-    conn = op.get_bind()
-
-    last_id = 0
-    while True:
-        rows = conn.execute(
-            sa.text(
-                "SELECT id, content FROM chunks "
-                "WHERE id > :last_id ORDER BY id LIMIT :lim"
-            ),
-            {"last_id": last_id, "lim": _BATCH_SIZE},
-        ).fetchall()
-
-        if not rows:
-            break
-
-        params = [
-            {"c": row.content or "", "id": row.id}
-            for row in rows
-        ]
-        conn.execute(
-            sa.text("UPDATE chunks SET tsv = to_tsvector('simple', :c) WHERE id = :id"),
-            params,
-        )
-
-        last_id = rows[-1].id
-
-    conn.execute(sa.text("ANALYZE chunks"))
+    pass  # No schema changes to revert

--- a/scripts/backfill_morpheme_tsvectors.py
+++ b/scripts/backfill_morpheme_tsvectors.py
@@ -1,0 +1,99 @@
+"""Backfill chunk tsvectors with kiwipiepy morpheme tokenization.
+
+One-time script to rebuild existing chunks' tsv column using morpheme-split tokens.
+New chunks are tokenized at insert time, so this only needs to run once on
+servers that had chunks before Phase B was deployed.
+
+Usage:
+    python scripts/backfill_morpheme_tsvectors.py
+
+Safe to run multiple times (idempotent).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Allow running from repo root
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import sqlalchemy as sa
+from dotenv import load_dotenv
+
+load_dotenv()
+
+_BATCH_SIZE = 500
+
+
+def _make_kiwi():
+    try:
+        from kiwipiepy import Kiwi  # type: ignore[import]
+    except ImportError:
+        raise ImportError("kiwipiepy is required. Run: pip install kiwipiepy")
+    return Kiwi()
+
+
+def _tokenize(kiwi, text: str) -> str:
+    tokens = kiwi.tokenize(text)
+    return " ".join(
+        t.form for t in tokens
+        if t.tag.startswith(("NN", "VV", "SL", "XR"))
+    )
+
+
+def main() -> None:
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL environment variable is not set")
+
+    # asyncpg URL → sync psycopg2-compatible URL
+    sync_url = database_url.replace("postgresql+asyncpg://", "postgresql://")
+
+    engine = sa.create_engine(sync_url)
+    kiwi = _make_kiwi()
+
+    with engine.connect() as conn:
+        total = conn.execute(sa.text("SELECT COUNT(*) FROM chunks")).scalar() or 0
+        if total == 0:
+            print("No chunks to backfill.")
+            return
+
+        print(f"Backfilling {total} chunks...")
+        last_id = 0
+        updated = 0
+
+        while True:
+            rows = conn.execute(
+                sa.text(
+                    "SELECT id, content FROM chunks "
+                    "WHERE id > :last_id ORDER BY id LIMIT :lim"
+                ),
+                {"last_id": last_id, "lim": _BATCH_SIZE},
+            ).fetchall()
+
+            if not rows:
+                break
+
+            params = [
+                {"mc": _tokenize(kiwi, row.content or ""), "id": row.id}
+                for row in rows
+            ]
+            conn.execute(
+                sa.text("UPDATE chunks SET tsv = to_tsvector('simple', :mc) WHERE id = :id"),
+                params,
+            )
+            conn.commit()
+
+            updated += len(rows)
+            last_id = rows[-1].id
+            print(f"  {updated}/{total} done...")
+
+        conn.execute(sa.text("ANALYZE chunks"))
+        conn.commit()
+
+    print(f"Done. {updated} chunks updated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `deploy.yml`에서 `docker compose exec -T app alembic upgrade head` 제거
- `0006` migration을 no-op 마커로 변경 (데이터 백필 분리)
- `scripts/backfill_morpheme_tsvectors.py` 추가 (수동 실행용)

## 문제
`entrypoint.sh`가 이미 `alembic upgrade head`를 실행하므로 deploy.yml의 exec는 중복이었음.
더 큰 문제: `0006` 마이그레이션이 모든 chunks를 kiwipiepy로 재처리 → entrypoint에서 uvicorn 시작 전 20분+ 블로킹 → 사용자 서비스 불가

## 변경 후 배포 흐름
```
docker compose up -d --build
  └─ entrypoint.sh 실행
       ├─ alembic upgrade head  (DDL only, 수 초)
       └─ uvicorn 시작          (즉시 서비스 가능)
```

## 기존 데이터 백필 필요 시
```bash
python scripts/backfill_morpheme_tsvectors.py
```

## Test plan
- [x] 현재 서버: 0006 이미 적용됨 → 영향 없음
- [x] 신규 설치: chunks 없음 → 백필 불필요
- [x] entrypoint.sh 중복 제거로 배포 시간 단축

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined deployment workflow by removing a manual database initialization step.

* **Refactor**
  * Migrated data backfill operations from the migration process into a dedicated utility script for improved modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->