### PR TITLE
[fix/#101] 스케줄러 주간 리포트 Depends 객체 주입 버그 수정

### DIFF
--- a/app/api/dependencies/report_di.py
+++ b/app/api/dependencies/report_di.py
@@ -43,7 +43,7 @@ def build_weekly_report_usecase(session: AsyncSession) -> GenerateWeeklyReportUs
     from app.api.dependencies.auth_di import get_user_repository, get_telegram_client
     from app.api.dependencies.link_di import get_openai_client, get_link_repository
 
-    user_repo: IUserRepository = get_user_repository()
+    user_repo: IUserRepository = get_user_repository(session)
     link_repo: ILinkRepository = get_link_repository(session)
     rec_repo: IRecommendationRepository = get_recommendation_repository(session)
     openai: AIAnalysisPort = get_openai_client()


### PR DESCRIPTION
## 변경 사항

`build_weekly_report_usecase`에서 `get_user_repository()`를 인자 없이 호출하던 버그 수정.

## 원인

FastAPI DI 컨텍스트 밖(APScheduler)에서 `get_user_repository()`를 인자 없이 호출하면,
`db` 파라미터 기본값인 `Depends(get_db)` 객체 자체가 `UserRepository`에 주입됨.
이후 `self._db.execute()` 호출 시 `AttributeError: 'Depends' object has no attribute 'execute'` 발생.

## 수정 내용

`app/api/dependencies/report_di.py`

```python
# Before
user_repo: IUserRepository = get_user_repository()

# After
user_repo: IUserRepository = get_user_repository(session)
```

## 관련 이슈

Closes #101