### PR TITLE
[FIX/#105] semantic_summary를 Notion 본문에 직접 사용

### DIFF
--- a/app/application/usecases/save_link_usecase.py
+++ b/app/application/usecases/save_link_usecase.py
@@ -67,10 +67,9 @@ class SaveLinkUseCase:
             keywords: list[str] = analysis.keywords
             keywords_json = json.dumps(keywords, ensure_ascii=False)
 
-            # DB/임베딩용: 문장형 요약 (고유명사/맥락 보존)
+            # DB/임베딩/Notion 본문 공용: 문장형 요약 (고유명사/맥락 보존)
             summary: str = analysis.semantic_summary or description
-            # Notion 본문용: 줄바꿈 문단 포맷
-            ai_summary: str = "\n".join(point.strip() for point in analysis.display_points if point.strip())
+            ai_summary: str = summary
 
             # 2-1. Summary + chunks 임베딩을 1회 호출로 배치 처리
             # OG fallback은 메타데이터만 있어 청킹 불필요 (description ~200자)

--- a/app/core/prompts/analyze_content.py
+++ b/app/core/prompts/analyze_content.py
@@ -4,11 +4,9 @@ Respond in the same language as the input content.
 
 Rules:
 - title: one concise line, max 50 characters
-- semantic_summary: 4-6 sentences; preserve proper nouns, organization names, \
-dates, numbers, and key conclusions — optimized for semantic search and embeddings
-- display_points: 4-5 short lines for the Notion body; each line should read \
-like a natural sentence, include concrete details, and do NOT include bullet \
-markers
+- semantic_summary: one readable paragraph, 4-6 sentences; preserve proper \
+nouns, organization names, dates, numbers, and key conclusions — usable for \
+semantic search and as Notion body text
 - category: must be exactly one of: AI, Dev, Career, Business, Science, \
 Design, Health, Productivity, Education, Other
 - keywords: exactly 5 relevant keywords

--- a/app/domain/entities/content_analysis.py
+++ b/app/domain/entities/content_analysis.py
@@ -11,7 +11,6 @@ CategoryType = Literal[
 
 class ContentAnalysis(BaseModel):
     title: str
-    semantic_summary: str       # 임베딩/DB용 (4~6문장, 고유명사/맥락 보존)
-    display_points: list[str]   # Notion 본문용 짧은 요약 라인 (4~5개)
+    semantic_summary: str       # DB/임베딩/Notion 본문 공용 요약 문단
     category: CategoryType
     keywords: list[str]

--- a/tests/test_analyze_content_prompt.py
+++ b/tests/test_analyze_content_prompt.py
@@ -4,11 +4,10 @@ from app.core.prompts.analyze_content import ANALYZE_CONTENT_PROMPT
 
 
 class AnalyzeContentPromptTest(unittest.TestCase):
-    def test_prompt_requests_natural_lines_without_bullets(self):
-        self.assertIn("display_points: 4-5 short lines", ANALYZE_CONTENT_PROMPT)
-        self.assertIn("natural sentence", ANALYZE_CONTENT_PROMPT)
-        self.assertIn("include concrete details", ANALYZE_CONTENT_PROMPT)
-        self.assertIn("do NOT include bullet markers", ANALYZE_CONTENT_PROMPT)
+    def test_prompt_uses_single_readable_semantic_summary(self):
+        self.assertIn("semantic_summary: one readable paragraph", ANALYZE_CONTENT_PROMPT)
+        self.assertIn("usable for semantic search and as Notion body text", ANALYZE_CONTENT_PROMPT)
+        self.assertNotIn("display_points", ANALYZE_CONTENT_PROMPT)
 
 
 if __name__ == "__main__":

--- a/tests/test_notion_summary_format.py
+++ b/tests/test_notion_summary_format.py
@@ -107,7 +107,7 @@ class NotionSummaryFormatTest(unittest.TestCase):
 
 
 class SaveLinkUseCaseSummaryFormattingTest(unittest.IsolatedAsyncioTestCase):
-    async def test_display_points_are_joined_without_bullet_prefixes(self):
+    async def test_semantic_summary_is_sent_to_notion_body(self):
         deps = {
             "db": AsyncMock(),
             "user_repo": AsyncMock(),
@@ -131,13 +131,7 @@ class SaveLinkUseCaseSummaryFormattingTest(unittest.IsolatedAsyncioTestCase):
         )
         deps["openai"].analyze_content.return_value = SimpleNamespace(
             title="AI Title",
-            semantic_summary="문장형 요약",
-            display_points=[
-                "첫 줄은 자연스러운 요약문이다.",
-                "둘째 줄은 구체 정보를 담는다.",
-                "셋째 줄은 추가 맥락을 담는다.",
-                "넷째 줄은 일정이나 수치를 담는다.",
-            ],
+            semantic_summary="문장형 요약이다. 핵심 맥락과 중요한 정보를 자연스럽게 설명한다.",
             category="AI",
             keywords=["a", "b", "c", "d", "e"],
         )
@@ -158,12 +152,7 @@ class SaveLinkUseCaseSummaryFormattingTest(unittest.IsolatedAsyncioTestCase):
             category="AI",
             keywords=["a", "b", "c", "d", "e"],
             description="OG meta description",
-            ai_summary=(
-                "첫 줄은 자연스러운 요약문이다.\n"
-                "둘째 줄은 구체 정보를 담는다.\n"
-                "셋째 줄은 추가 맥락을 담는다.\n"
-                "넷째 줄은 일정이나 수치를 담는다."
-            ),
+            ai_summary="문장형 요약이다. 핵심 맥락과 중요한 정보를 자연스럽게 설명한다.",
             url="https://example.com/post",
             memo=None,
         )

--- a/tests/test_save_link_usecase.py
+++ b/tests/test_save_link_usecase.py
@@ -65,7 +65,6 @@ async def test_jina_source_embedding_batched_once_for_summary_and_chunks(save_li
     openai.analyze_content.return_value = ContentAnalysis(
         title="테스트 제목",
         semantic_summary=semantic_summary,
-        display_points=["point one", "point two"],
         category="AI",
         keywords=["a", "b", "c", "d", "e"],
     )
@@ -89,11 +88,11 @@ async def test_jina_source_embedding_batched_once_for_summary_and_chunks(save_li
 
 
 @pytest.mark.asyncio
-async def test_semantic_summary_stored_in_db_display_points_sent_to_notion(
+async def test_semantic_summary_stored_in_db_and_sent_to_notion(
     save_link_usecase,
     save_link_dependencies,
 ):
-    """semantic_summary는 DB summary에, display_points는 줄바꿈 포맷으로 Notion ai_summary에 전달된다."""
+    """semantic_summary는 DB summary와 Notion ai_summary에 함께 사용된다."""
     user_repo = save_link_dependencies["user_repo"]
     link_repo = save_link_dependencies["link_repo"]
     openai = save_link_dependencies["openai"]
@@ -104,8 +103,6 @@ async def test_semantic_summary_stored_in_db_display_points_sent_to_notion(
     og_description = "OG meta description"
     og_title = "OG Page Title"
     semantic_summary = "하나증권은 2026 신입 공채를 실시한다. AI 직무 포함 다수 부문 채용 예정이다."
-    display_points = ["AI 직무 포함 신입 공채", "지원 자격: 학사 이상", "마감: 2026-03-31"]
-    expected_ai_summary = "AI 직무 포함 신입 공채\n지원 자격: 학사 이상\n마감: 2026-03-31"
     notion_page_url = "https://www.notion.so/workspace/child-page"
 
     link_repo.exists_by_user_and_url.return_value = False
@@ -113,7 +110,6 @@ async def test_semantic_summary_stored_in_db_display_points_sent_to_notion(
     openai.analyze_content.return_value = ContentAnalysis(
         title="AI Title",
         semantic_summary=semantic_summary,
-        display_points=display_points,
         category="AI",
         keywords=["a", "b", "c", "d", "e"],
     )
@@ -131,7 +127,7 @@ async def test_semantic_summary_stored_in_db_display_points_sent_to_notion(
     # og_title이 title로 사용됨
     assert save_link_kwargs["title"] == og_title
 
-    # Notion은 description(og_description)과 display_points 기반 줄바꿈 요약을 분리해서 받음
+    # Notion은 description(og_description)과 semantic_summary 기반 본문을 분리해서 받음
     notion.create_database_entry.assert_awaited_once_with(
         access_token="secret",
         database_id="db-123",
@@ -139,7 +135,7 @@ async def test_semantic_summary_stored_in_db_display_points_sent_to_notion(
         category="AI",
         keywords=["a", "b", "c", "d", "e"],
         description=og_description,
-        ai_summary=expected_ai_summary,
+        ai_summary=semantic_summary,
         url="https://example.com/post",
         memo=None,
     )
@@ -161,7 +157,6 @@ async def test_og_source_skips_chunking(save_link_usecase, save_link_dependencie
     openai.analyze_content.return_value = ContentAnalysis(
         title="Title",
         semantic_summary="이 링크는 짧은 설명을 담고 있다.",
-        display_points=["AI 관련 내용"],
         category="Dev",
         keywords=["a", "b", "c", "d", "e"],
     )


### PR DESCRIPTION
## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
related #105
follow-up to #106

## 📝 𝗦𝘂𝗺𝗺𝗮𝗿𝘆
- save-link 분석 결과에서 `display_points` 분리 계약을 제거했습니다.
- 단일 chat completion 결과인 `semantic_summary`를 DB summary와 Notion 본문에 함께 사용하도록 단순화했습니다.
- prompt를 한 문단 요약 기준으로 정리하고 관련 테스트를 갱신했습니다.

## 🧪 𝗧𝗲𝘀𝘁
> 이 PR을 로컬에서 테스트하려면 다음을 실행하세요:
```bash
python3 -m unittest tests.test_analyze_content_prompt tests.test_notion_summary_format
python3 -m py_compile app/core/prompts/analyze_content.py app/domain/entities/content_analysis.py app/application/usecases/save_link_usecase.py tests/test_analyze_content_prompt.py tests/test_notion_summary_format.py tests/test_save_link_usecase.py
```

> **필수 테스트:**
- [ ] 웹훅 엔드포인트: `POST /api/v1/webhook/telegram` (tests/test_webhook.http 참고)
- [ ] `/start`, `/memo`, `/search`, `/ask` 명령어 정상 작동
- [ ] URL 저장 정상 작동

## 📸 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| semantic_summary를 Notion 본문에 직접 사용 | N/A |

## 💡 𝗥𝗲𝗳𝗲𝗿𝗲𝗻𝗰𝗲
- merged PR #106 이후 추가된 후속 변경입니다.
- refactor/#103-remove-kiwi-plugin 작업선과는 계속 분리되어 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated content summary generation to produce single readable paragraphs instead of multi-part formatted sections. Summary processing is now unified across database storage, semantic search, and content management features, improving consistency and simplifying downstream processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->