### PR TITLE
[FIX/#118] Repair weekly report Telegram formatting

### DIFF
--- a/app/application/usecases/generate_weekly_report_usecase.py
+++ b/app/application/usecases/generate_weekly_report_usecase.py
@@ -66,20 +66,14 @@ class GenerateWeeklyReportUseCase:
             return
 
         sent_since = send_anchor.astimezone(timezone.utc)
-        users = await self._user_repo.get_all_users()
-        for user in users:
+        user_ids = await self._rec_repo.get_user_ids_without_recommendation_since(sent_since)
+        for user_id in user_ids:
             try:
-                already_sent = await self._rec_repo.has_recommendation_since(
-                    user.telegram_id,
-                    sent_since,
-                )
-                if already_sent:
-                    continue
-                await self.execute(user.telegram_id)
+                await self.execute(user_id)
             except Exception as exc:
                 await self._db.rollback()
                 logger.exception(
-                    f"Weekly report catch-up failed for user {user.telegram_id}: {exc}"
+                    f"Weekly report catch-up failed for user {user_id}: {exc}"
                 )
 
     async def execute(self, user_id: int) -> None:

--- a/app/application/usecases/generate_weekly_report_usecase.py
+++ b/app/application/usecases/generate_weekly_report_usecase.py
@@ -1,4 +1,14 @@
-"""Generate and send weekly knowledge reports."""
+"""주간 리포트 생성 UseCase.
+
+Flow:
+1. 관심사 Drift 계산 (최근 7일 vs 과거 30일 카테고리 비중)
+2. Interest Centroid 계산 (최근 7일 임베딩, 없으면 전체 폴백)
+3. 최근 14일 추천 이력 제외하고 재활성화 후보 조회
+4. Reactivation Score 기반 최적 링크 1개 선정
+5. LLM_ANALYSIS(gpt-4.1-mini)로 브리핑 생성
+6. Telegram 푸시 (읽음 처리 버튼 포함)
+7. 추천 이력 기록 + DB 커밋
+"""
 
 import html
 from datetime import datetime, timedelta, timezone
@@ -7,12 +17,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.application.ports.ai_analysis_port import AIAnalysisPort
 from app.application.ports.telegram_port import TelegramPort
-from app.core.logger import logger
 from app.domain.drift import calculate_drift
 from app.domain.repositories.i_link_repository import ILinkRepository
 from app.domain.repositories.i_recommendation_repository import IRecommendationRepository
 from app.domain.repositories.i_user_repository import IUserRepository
 from app.domain.scoring import compute_interest_centroid, select_reactivation_link
+
+from app.core.logger import logger
 
 
 class GenerateWeeklyReportUseCase:
@@ -33,22 +44,24 @@ class GenerateWeeklyReportUseCase:
         self._telegram = telegram
 
     async def execute_for_all_users(self) -> None:
-        """Run the weekly report job for every known user."""
+        """전체 유저 대상 주간 리포트 실행 (스케줄러 진입점)."""
         users = await self._user_repo.get_all_users()
         for user in users:
             try:
                 await self.execute(user.telegram_id)
             except Exception as exc:
                 await self._db.rollback()
-                logger.exception(f"Weekly report failed for user {user.telegram_id}: {exc}")
+                logger.exception(
+                    f"Weekly report failed for user {user.telegram_id}: {exc}"
+                )
 
     async def execute(self, user_id: int) -> None:
-        """Generate and send a weekly report to a single user."""
+        """단일 유저 주간 리포트 생성 및 전송."""
         now = datetime.now(timezone.utc)
         week_ago = now - timedelta(days=7)
         month_ago = now - timedelta(days=30)
 
-        # 1. Measure interest drift using the last 7 days vs the prior 23 days.
+        # 1. Drift 계산 (current: 최근 7일, past: 7일~30일 — 겹침 없이 분리)
         current_cats = await self._link_repo.get_categories_by_period(user_id, week_ago, now)
         past_cats = await self._link_repo.get_categories_by_period(user_id, month_ago, week_ago)
         if len(current_cats) >= 3:
@@ -56,7 +69,7 @@ class GenerateWeeklyReportUseCase:
         else:
             tvd, delta = 0.0, {}
 
-        # 2. Build the user's current interest centroid, with a full-history fallback.
+        # 2. Interest Centroid (최근 7일 → 전체 폴백)
         recent_embs = await self._link_repo.get_summary_embeddings_by_period(user_id, week_ago, now)
         if not recent_embs:
             recent_embs = await self._link_repo.get_all_summary_embeddings(user_id)
@@ -66,14 +79,12 @@ class GenerateWeeklyReportUseCase:
             logger.info(f"User {user_id} has no embeddings, skipping weekly report")
             return
 
-        # 3. Exclude links that were already recommended recently.
+        # 3. 최근 14일 추천 이력 제외
         excluded_ids = await self._rec_repo.get_recently_recommended_link_ids(user_id, within_days=14)
 
-        # 4. Pick the best stale unread link to reactivate.
+        # 4. 재활성화 후보 조회 + 최적 링크 선정
         candidates = await self._link_repo.get_reactivation_candidates(
-            user_id,
-            older_than_days=7,
-            excluded_ids=excluded_ids,
+            user_id, older_than_days=7, excluded_ids=excluded_ids
         )
         best = select_reactivation_link(candidates, centroid)
 
@@ -81,12 +92,12 @@ class GenerateWeeklyReportUseCase:
             logger.info(f"User {user_id} has no reactivation candidates, skipping")
             return
 
-        # 5. Ask the LLM to turn the data into a short weekly briefing.
+        # 5. LLM 브리핑 생성
         briefing = await self._openai.generate_briefing(
             _build_briefing_prompt(best, tvd, delta, current_cats)
         )
 
-        # 6. Send the report via Telegram and include a mark-read action.
+        # 6. Telegram 전송 (읽음 처리 버튼 포함)
         message = _build_report_message(briefing, best)
         await self._telegram.send_weekly_report(
             chat_id=user_id,
@@ -94,7 +105,7 @@ class GenerateWeeklyReportUseCase:
             link_id=best["link_id"],
         )
 
-        # 7. Persist the recommendation only after the delivery succeeds.
+        # 7. 추천 이력 기록 + 단일 커밋
         await self._rec_repo.record(link_id=best["link_id"], user_id=user_id)
         await self._db.commit()
 
@@ -107,19 +118,19 @@ def _build_briefing_prompt(
 ) -> str:
     if tvd > 0.1:
         top_gains = sorted(
-            [(category, change) for category, change in delta.items() if change > 0],
-            key=lambda item: item[1],
+            [(c, d) for c, d in delta.items() if d > 0],
+            key=lambda t: t[1],
             reverse=True,
         )[:2]
         top_losses = sorted(
-            [(category, change) for category, change in delta.items() if change < 0],
-            key=lambda item: item[1],
+            [(c, d) for c, d in delta.items() if d < 0],
+            key=lambda t: t[1],
         )[:2]
         drift_lines = []
-        for category, change in top_gains:
-            drift_lines.append(f"  ▲ {category} (+{change:.0%})")
-        for category, change in top_losses:
-            drift_lines.append(f"  ▼ {category} ({change:.0%})")
+        for c, d in top_gains:
+            drift_lines.append(f"  ▲ {c} (+{d:.0%})")
+        for c, d in top_losses:
+            drift_lines.append(f"  ▼ {c} ({d:.0%})")
         drift_summary = "Interest drift:\n" + "\n".join(drift_lines)
     else:
         drift_summary = "Interest drift: stable (no significant change)"
@@ -150,9 +161,9 @@ def _build_report_message(briefing: str, best: dict) -> str:
     url = best.get("url", "")
     url_line = f'\n🔗 <a href="{html.escape(url)}">{html.escape(url)}</a>' if url else ""
     return (
-        f"🧠 <b>이번 주 지식 리포트</b>\n\n"
+        f"📊 <b>이번 주 지식 리포트</b>\n\n"
         f"{html.escape(briefing)}\n\n"
-        f"────────────────\n"
+        f"━━━━━━━━━━━━━━━\n"
         f"📌 <b>다시 보기 추천</b>\n"
         f"<b>{title}</b>{url_line}"
     )

--- a/app/application/usecases/generate_weekly_report_usecase.py
+++ b/app/application/usecases/generate_weekly_report_usecase.py
@@ -12,18 +12,20 @@ Flow:
 
 import html
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.application.ports.ai_analysis_port import AIAnalysisPort
 from app.application.ports.telegram_port import TelegramPort
+from app.core.logger import logger
 from app.domain.drift import calculate_drift
 from app.domain.repositories.i_link_repository import ILinkRepository
 from app.domain.repositories.i_recommendation_repository import IRecommendationRepository
 from app.domain.repositories.i_user_repository import IUserRepository
 from app.domain.scoring import compute_interest_centroid, select_reactivation_link
 
-from app.core.logger import logger
+KST = ZoneInfo("Asia/Seoul")
 
 
 class GenerateWeeklyReportUseCase:
@@ -55,6 +57,31 @@ class GenerateWeeklyReportUseCase:
                     f"Weekly report failed for user {user.telegram_id}: {exc}"
                 )
 
+    async def execute_startup_catch_up(self, now: datetime | None = None) -> None:
+        """앱 시작 시 이번 주 주간 리포트 누락분이 있으면 보충 발송."""
+        effective_now = now or datetime.now(timezone.utc)
+        send_anchor = _current_week_send_anchor(effective_now)
+        if effective_now.astimezone(KST) < send_anchor:
+            logger.info("Weekly report catch-up skipped before this week's Monday 09:00 KST")
+            return
+
+        sent_since = send_anchor.astimezone(timezone.utc)
+        users = await self._user_repo.get_all_users()
+        for user in users:
+            try:
+                already_sent = await self._rec_repo.has_recommendation_since(
+                    user.telegram_id,
+                    sent_since,
+                )
+                if already_sent:
+                    continue
+                await self.execute(user.telegram_id)
+            except Exception as exc:
+                await self._db.rollback()
+                logger.exception(
+                    f"Weekly report catch-up failed for user {user.telegram_id}: {exc}"
+                )
+
     async def execute(self, user_id: int) -> None:
         """단일 유저 주간 리포트 생성 및 전송."""
         now = datetime.now(timezone.utc)
@@ -84,7 +111,9 @@ class GenerateWeeklyReportUseCase:
 
         # 4. 재활성화 후보 조회 + 최적 링크 선정
         candidates = await self._link_repo.get_reactivation_candidates(
-            user_id, older_than_days=7, excluded_ids=excluded_ids
+            user_id,
+            older_than_days=7,
+            excluded_ids=excluded_ids,
         )
         best = select_reactivation_link(candidates, centroid)
 
@@ -97,7 +126,7 @@ class GenerateWeeklyReportUseCase:
             _build_briefing_prompt(best, tvd, delta, current_cats)
         )
 
-        # 6. Telegram 전송 (읽음 처리 버튼 포함)
+        # 6. Telegram 푸시 (읽음 처리 버튼 포함)
         message = _build_report_message(briefing, best)
         await self._telegram.send_weekly_report(
             chat_id=user_id,
@@ -105,7 +134,7 @@ class GenerateWeeklyReportUseCase:
             link_id=best["link_id"],
         )
 
-        # 7. 추천 이력 기록 + 단일 커밋
+        # 7. 추천 이력 기록 + DB 커밋
         await self._rec_repo.record(link_id=best["link_id"], user_id=user_id)
         await self._db.commit()
 
@@ -167,3 +196,9 @@ def _build_report_message(briefing: str, best: dict) -> str:
         f"📌 <b>다시 보기 추천</b>\n"
         f"<b>{title}</b>{url_line}"
     )
+
+
+def _current_week_send_anchor(now: datetime) -> datetime:
+    local_now = now.astimezone(KST)
+    monday = local_now - timedelta(days=local_now.weekday())
+    return monday.replace(hour=9, minute=0, second=0, microsecond=0)

--- a/app/application/usecases/generate_weekly_report_usecase.py
+++ b/app/application/usecases/generate_weekly_report_usecase.py
@@ -33,6 +33,7 @@ class GenerateWeeklyReportUseCase:
         self._telegram = telegram
 
     async def execute_for_all_users(self) -> None:
+        """Run the weekly report job for every known user."""
         users = await self._user_repo.get_all_users()
         for user in users:
             try:
@@ -42,10 +43,12 @@ class GenerateWeeklyReportUseCase:
                 logger.exception(f"Weekly report failed for user {user.telegram_id}: {exc}")
 
     async def execute(self, user_id: int) -> None:
+        """Generate and send a weekly report to a single user."""
         now = datetime.now(timezone.utc)
         week_ago = now - timedelta(days=7)
         month_ago = now - timedelta(days=30)
 
+        # 1. Measure interest drift using the last 7 days vs the prior 23 days.
         current_cats = await self._link_repo.get_categories_by_period(user_id, week_ago, now)
         past_cats = await self._link_repo.get_categories_by_period(user_id, month_ago, week_ago)
         if len(current_cats) >= 3:
@@ -53,6 +56,7 @@ class GenerateWeeklyReportUseCase:
         else:
             tvd, delta = 0.0, {}
 
+        # 2. Build the user's current interest centroid, with a full-history fallback.
         recent_embs = await self._link_repo.get_summary_embeddings_by_period(user_id, week_ago, now)
         if not recent_embs:
             recent_embs = await self._link_repo.get_all_summary_embeddings(user_id)
@@ -62,7 +66,10 @@ class GenerateWeeklyReportUseCase:
             logger.info(f"User {user_id} has no embeddings, skipping weekly report")
             return
 
+        # 3. Exclude links that were already recommended recently.
         excluded_ids = await self._rec_repo.get_recently_recommended_link_ids(user_id, within_days=14)
+
+        # 4. Pick the best stale unread link to reactivate.
         candidates = await self._link_repo.get_reactivation_candidates(
             user_id,
             older_than_days=7,
@@ -74,10 +81,12 @@ class GenerateWeeklyReportUseCase:
             logger.info(f"User {user_id} has no reactivation candidates, skipping")
             return
 
+        # 5. Ask the LLM to turn the data into a short weekly briefing.
         briefing = await self._openai.generate_briefing(
             _build_briefing_prompt(best, tvd, delta, current_cats)
         )
 
+        # 6. Send the report via Telegram and include a mark-read action.
         message = _build_report_message(briefing, best)
         await self._telegram.send_weekly_report(
             chat_id=user_id,
@@ -85,6 +94,7 @@ class GenerateWeeklyReportUseCase:
             link_id=best["link_id"],
         )
 
+        # 7. Persist the recommendation only after the delivery succeeds.
         await self._rec_repo.record(link_id=best["link_id"], user_id=user_id)
         await self._db.commit()
 
@@ -107,9 +117,9 @@ def _build_briefing_prompt(
         )[:2]
         drift_lines = []
         for category, change in top_gains:
-            drift_lines.append(f"  - {category} (+{change:.0%})")
+            drift_lines.append(f"  ▲ {category} (+{change:.0%})")
         for category, change in top_losses:
-            drift_lines.append(f"  - {category} ({change:.0%})")
+            drift_lines.append(f"  ▼ {category} ({change:.0%})")
         drift_summary = "Interest drift:\n" + "\n".join(drift_lines)
     else:
         drift_summary = "Interest drift: stable (no significant change)"

--- a/app/application/usecases/generate_weekly_report_usecase.py
+++ b/app/application/usecases/generate_weekly_report_usecase.py
@@ -1,14 +1,5 @@
-"""주간 리포트 생성 UseCase.
+"""Generate and send weekly knowledge reports."""
 
-Flow:
-1. 관심사 Drift 계산 (최근 7일 vs 과거 30일 카테고리 비중)
-2. Interest Centroid 계산 (최근 7일 임베딩, 없으면 전체 폴백)
-3. 최근 14일 추천 이력 제외하고 재활성화 후보 조회
-4. Reactivation Score 기반 최적 링크 1개 선정
-5. LLM_ANALYSIS(gpt-4.1-mini)로 브리핑 생성
-6. Telegram 푸시 (읽음 처리 버튼 포함)
-7. 추천 이력 기록 + DB 커밋
-"""
 import html
 from datetime import datetime, timedelta, timezone
 
@@ -16,13 +7,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.application.ports.ai_analysis_port import AIAnalysisPort
 from app.application.ports.telegram_port import TelegramPort
+from app.core.logger import logger
 from app.domain.drift import calculate_drift
 from app.domain.repositories.i_link_repository import ILinkRepository
 from app.domain.repositories.i_recommendation_repository import IRecommendationRepository
 from app.domain.repositories.i_user_repository import IUserRepository
 from app.domain.scoring import compute_interest_centroid, select_reactivation_link
-
-from app.core.logger import logger
 
 
 class GenerateWeeklyReportUseCase:
@@ -43,24 +33,19 @@ class GenerateWeeklyReportUseCase:
         self._telegram = telegram
 
     async def execute_for_all_users(self) -> None:
-        """전체 유저 대상 주간 리포트 실행 (스케줄러 진입점)."""
         users = await self._user_repo.get_all_users()
         for user in users:
             try:
                 await self.execute(user.telegram_id)
             except Exception as exc:
                 await self._db.rollback()
-                logger.exception(
-                    f"Weekly report failed for user {user.telegram_id}: {exc}"
-                )
+                logger.exception(f"Weekly report failed for user {user.telegram_id}: {exc}")
 
     async def execute(self, user_id: int) -> None:
-        """단일 유저 주간 리포트 생성 및 전송."""
         now = datetime.now(timezone.utc)
         week_ago = now - timedelta(days=7)
         month_ago = now - timedelta(days=30)
 
-        # 1. Drift 계산 (current: 최근 7일, past: 7일~30일 — 겹침 없이 분리)
         current_cats = await self._link_repo.get_categories_by_period(user_id, week_ago, now)
         past_cats = await self._link_repo.get_categories_by_period(user_id, month_ago, week_ago)
         if len(current_cats) >= 3:
@@ -68,7 +53,6 @@ class GenerateWeeklyReportUseCase:
         else:
             tvd, delta = 0.0, {}
 
-        # 2. Interest Centroid (최근 7일 → 전체 폴백)
         recent_embs = await self._link_repo.get_summary_embeddings_by_period(user_id, week_ago, now)
         if not recent_embs:
             recent_embs = await self._link_repo.get_all_summary_embeddings(user_id)
@@ -78,12 +62,11 @@ class GenerateWeeklyReportUseCase:
             logger.info(f"User {user_id} has no embeddings, skipping weekly report")
             return
 
-        # 3. 최근 14일 추천 이력 제외
         excluded_ids = await self._rec_repo.get_recently_recommended_link_ids(user_id, within_days=14)
-
-        # 4. 재활성화 후보 조회 + 최적 링크 선정
         candidates = await self._link_repo.get_reactivation_candidates(
-            user_id, older_than_days=7, excluded_ids=excluded_ids
+            user_id,
+            older_than_days=7,
+            excluded_ids=excluded_ids,
         )
         best = select_reactivation_link(candidates, centroid)
 
@@ -91,12 +74,10 @@ class GenerateWeeklyReportUseCase:
             logger.info(f"User {user_id} has no reactivation candidates, skipping")
             return
 
-        # 5. LLM 브리핑 생성
         briefing = await self._openai.generate_briefing(
             _build_briefing_prompt(best, tvd, delta, current_cats)
         )
 
-        # 6. Telegram 전송 (읽음 처리 버튼 포함)
         message = _build_report_message(briefing, best)
         await self._telegram.send_weekly_report(
             chat_id=user_id,
@@ -104,7 +85,6 @@ class GenerateWeeklyReportUseCase:
             link_id=best["link_id"],
         )
 
-        # 7. 추천 이력 기록 + 단일 커밋
         await self._rec_repo.record(link_id=best["link_id"], user_id=user_id)
         await self._db.commit()
 
@@ -117,19 +97,19 @@ def _build_briefing_prompt(
 ) -> str:
     if tvd > 0.1:
         top_gains = sorted(
-            [(c, d) for c, d in delta.items() if d > 0],
-            key=lambda t: t[1],
+            [(category, change) for category, change in delta.items() if change > 0],
+            key=lambda item: item[1],
             reverse=True,
         )[:2]
         top_losses = sorted(
-            [(c, d) for c, d in delta.items() if d < 0],
-            key=lambda t: t[1],
+            [(category, change) for category, change in delta.items() if change < 0],
+            key=lambda item: item[1],
         )[:2]
         drift_lines = []
-        for c, d in top_gains:
-            drift_lines.append(f"  ▲ {c} (+{d:.0%})")
-        for c, d in top_losses:
-            drift_lines.append(f"  ▼ {c} ({d:.0%})")
+        for category, change in top_gains:
+            drift_lines.append(f"  - {category} (+{change:.0%})")
+        for category, change in top_losses:
+            drift_lines.append(f"  - {category} ({change:.0%})")
         drift_summary = "Interest drift:\n" + "\n".join(drift_lines)
     else:
         drift_summary = "Interest drift: stable (no significant change)"
@@ -160,9 +140,9 @@ def _build_report_message(briefing: str, best: dict) -> str:
     url = best.get("url", "")
     url_line = f'\n🔗 <a href="{html.escape(url)}">{html.escape(url)}</a>' if url else ""
     return (
-        f"📊 <b>이번 주 지식 리포트</b>\n\n"
+        f"🧠 <b>이번 주 지식 리포트</b>\n\n"
         f"{html.escape(briefing)}\n\n"
-        f"━━━━━━━━━━━━━━━\n"
+        f"────────────────\n"
         f"📌 <b>다시 보기 추천</b>\n"
         f"<b>{title}</b>{url_line}"
     )

--- a/app/domain/repositories/i_recommendation_repository.py
+++ b/app/domain/repositories/i_recommendation_repository.py
@@ -20,10 +20,9 @@ class IRecommendationRepository(ABC):
         ...
 
     @abstractmethod
-    async def has_recommendation_since(
+    async def get_user_ids_without_recommendation_since(
         self,
-        user_id: int,
         since: datetime,
-    ) -> bool:
-        """주어진 시점 이후 추천 기록이 있는지 반환."""
+    ) -> list[int]:
+        """주어진 시점 이후 추천 기록이 없는 유저 ID 목록 반환."""
         ...

--- a/app/domain/repositories/i_recommendation_repository.py
+++ b/app/domain/repositories/i_recommendation_repository.py
@@ -18,3 +18,12 @@ class IRecommendationRepository(ABC):
     ) -> list[int]:
         """최근 N일 이내 이미 추천된 link_id 목록 반환 (중복 추천 방지용)."""
         ...
+
+    @abstractmethod
+    async def has_recommendation_since(
+        self,
+        user_id: int,
+        since: datetime,
+    ) -> bool:
+        """주어진 시점 이후 추천 기록이 있는지 반환."""
+        ...

--- a/app/infrastructure/repository/recommendation_repository.py
+++ b/app/infrastructure/repository/recommendation_repository.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domain.repositories.i_recommendation_repository import IRecommendationRepository
 from app.models.recommendation import Recommendation
+from app.models.user import User
 
 
 class RecommendationRepository(IRecommendationRepository):
@@ -30,15 +31,16 @@ class RecommendationRepository(IRecommendationRepository):
         )
         return list(result.scalars().all())
 
-    async def has_recommendation_since(
+    async def get_user_ids_without_recommendation_since(
         self,
-        user_id: int,
         since: datetime,
-    ) -> bool:
-        result = await self._db.execute(
-            select(Recommendation.id).where(
-                Recommendation.user_id == user_id,
-                Recommendation.recommended_at >= since,
-            ).limit(1)
+    ) -> list[int]:
+        subquery = (
+            select(Recommendation.user_id)
+            .where(Recommendation.recommended_at >= since)
+            .distinct()
         )
-        return result.scalar_one_or_none() is not None
+        result = await self._db.execute(
+            select(User.telegram_id).where(User.telegram_id.not_in(subquery))
+        )
+        return list(result.scalars().all())

--- a/app/infrastructure/repository/recommendation_repository.py
+++ b/app/infrastructure/repository/recommendation_repository.py
@@ -29,3 +29,16 @@ class RecommendationRepository(IRecommendationRepository):
             )
         )
         return list(result.scalars().all())
+
+    async def has_recommendation_since(
+        self,
+        user_id: int,
+        since: datetime,
+    ) -> bool:
+        result = await self._db.execute(
+            select(Recommendation.id).where(
+                Recommendation.user_id == user_id,
+                Recommendation.recommended_at >= since,
+            ).limit(1)
+        )
+        return result.scalar_one_or_none() is not None

--- a/app/infrastructure/scheduler.py
+++ b/app/infrastructure/scheduler.py
@@ -3,6 +3,7 @@
 매주 월요일 09:00 KST (= 00:00 UTC) 실행.
 FastAPI lifespan에서 start/stop.
 """
+
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
@@ -34,3 +35,17 @@ async def _run_weekly_report() -> None:
             logger.info("Weekly report job completed successfully")
         except Exception as exc:
             logger.exception(f"Weekly report job failed: {exc}")
+
+
+async def run_weekly_report_startup_catch_up() -> None:
+    """앱 시작 시 이번 주 주간 리포트 누락분이 있으면 보충 발송."""
+    from app.api.dependencies.report_di import build_weekly_report_usecase
+    from app.infrastructure.database import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as session:
+        try:
+            usecase = build_weekly_report_usecase(session)
+            await usecase.execute_startup_catch_up()
+            logger.info("Weekly report startup catch-up completed")
+        except Exception as exc:
+            logger.exception(f"Weekly report startup catch-up failed: {exc}")

--- a/app/main.py
+++ b/app/main.py
@@ -6,10 +6,10 @@ from app.core.logger import logger, setup_logging
 
 setup_logging()
 
-from app.api.v1.endpoints import auth, dashboard, search, webhook
 from app.api.dependencies.auth_di import get_telegram_client
+from app.api.v1.endpoints import auth, dashboard, search, webhook
 from app.core.config import settings
-from app.infrastructure.scheduler import create_scheduler
+from app.infrastructure.scheduler import create_scheduler, run_weekly_report_startup_catch_up
 
 
 @asynccontextmanager
@@ -30,6 +30,7 @@ async def lifespan(app: FastAPI):
     scheduler = create_scheduler()
     scheduler.start()
     logger.info("✅ Weekly report scheduler started")
+    await run_weekly_report_startup_catch_up()
 
     yield
 

--- a/tests/test_weekly_report.py
+++ b/tests/test_weekly_report.py
@@ -1,4 +1,4 @@
-"""GenerateWeeklyReportUseCase unit tests."""
+"""GenerateWeeklyReportUseCase 단위 테스트."""
 
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -10,6 +10,10 @@ from app.application.usecases.generate_weekly_report_usecase import (
     _build_report_message,
 )
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 def _make_user(telegram_id: int) -> MagicMock:
     user = MagicMock()
@@ -37,6 +41,10 @@ def _make_candidate(
     }
 
 
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
 @pytest.fixture
 def mock_db() -> AsyncMock:
     db = AsyncMock()
@@ -62,8 +70,13 @@ def usecase(mock_dependencies) -> GenerateWeeklyReportUseCase:
     return GenerateWeeklyReportUseCase(**mock_dependencies)
 
 
+# ---------------------------------------------------------------------------
+# TC1: Happy Path — 7단계 순서대로 실행, db.commit() 1회
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_happy_path(usecase, mock_dependencies, mock_db):
+    """정상 흐름: 7단계 모두 실행, db.commit() 정확히 1회."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
     openai = mock_dependencies["openai"]
@@ -83,8 +96,13 @@ async def test_happy_path(usecase, mock_dependencies, mock_db):
     mock_db.commit.assert_called_once()
 
 
+# ---------------------------------------------------------------------------
+# TC2: centroid 없음 → 조기 종료 (LLM/Telegram 미호출)
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_no_embeddings_early_return(usecase, mock_dependencies, mock_db):
+    """임베딩이 전혀 없으면 LLM·Telegram 호출 없이 조기 종료."""
     lr = mock_dependencies["link_repo"]
     openai = mock_dependencies["openai"]
     telegram = mock_dependencies["telegram"]
@@ -100,8 +118,13 @@ async def test_no_embeddings_early_return(usecase, mock_dependencies, mock_db):
     mock_db.commit.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# TC3: 재활성화 후보 없음 → 조기 종료
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_no_candidates_early_return(usecase, mock_dependencies, mock_db):
+    """재활성화 후보가 없으면 브리핑 생성·전송 미호출."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
     openai = mock_dependencies["openai"]
@@ -119,8 +142,13 @@ async def test_no_candidates_early_return(usecase, mock_dependencies, mock_db):
     mock_db.commit.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# TC4: execute_for_all_users — 3유저 → execute() 3회 호출
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_execute_for_all_users(usecase, mock_dependencies):
+    """전체 유저 3명에 대해 execute()가 각각 호출된다."""
     users = [_make_user(111), _make_user(222), _make_user(333)]
     mock_dependencies["user_repo"].get_all_users.return_value = users
 
@@ -132,8 +160,13 @@ async def test_execute_for_all_users(usecase, mock_dependencies):
     assert called_ids == [111, 222, 333]
 
 
+# ---------------------------------------------------------------------------
+# TC5: 에러 격리 — 222번 유저 실패 → rollback → 333번 계속 처리
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_error_isolation(usecase, mock_dependencies, mock_db):
+    """한 유저 실패 시 rollback 후 다음 유저 계속 처리."""
     users = [_make_user(111), _make_user(222), _make_user(333)]
     mock_dependencies["user_repo"].get_all_users.return_value = users
 
@@ -147,8 +180,13 @@ async def test_error_isolation(usecase, mock_dependencies, mock_db):
     mock_db.rollback.assert_called_once()
 
 
+# ---------------------------------------------------------------------------
+# TC6: 중복 추천 방지 — excluded_ids 파라미터 검증
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_excluded_ids_passed_to_candidates(usecase, mock_dependencies):
+    """rec_repo에서 받은 excluded_ids가 get_reactivation_candidates에 전달된다."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
 
@@ -163,8 +201,13 @@ async def test_excluded_ids_passed_to_candidates(usecase, mock_dependencies):
     assert call_kwargs["excluded_ids"] == [10, 20]
 
 
+# ---------------------------------------------------------------------------
+# TC7: 최근 7일 임베딩 없을 때 전체 폴백
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_recent_embeddings_empty_uses_all_fallback(usecase, mock_dependencies):
+    """최근 7일 임베딩이 없으면 get_all_summary_embeddings 폴백을 호출한다."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
 
@@ -179,13 +222,19 @@ async def test_recent_embeddings_empty_uses_all_fallback(usecase, mock_dependenc
     lr.get_all_summary_embeddings.assert_called_once_with(111)
 
 
+# ---------------------------------------------------------------------------
+# TC8: drift 임계값 미달 처리 (current_cats < 3)
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_drift_skipped_when_few_categories(usecase, mock_dependencies, mock_db):
+    """최근 카테고리가 3개 미만이면 drift 계산 생략 후 정상 실행."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
     openai = mock_dependencies["openai"]
     telegram = mock_dependencies["telegram"]
 
+    # 최근 카테고리 2개 → drift 계산 건너뜀
     lr.get_categories_by_period.return_value = ["AI", "Dev"]
     lr.get_summary_embeddings_by_period.return_value = [[0.1, 0.2, 0.3]]
     rr.get_recently_recommended_link_ids.return_value = []
@@ -194,13 +243,19 @@ async def test_drift_skipped_when_few_categories(usecase, mock_dependencies, moc
 
     await usecase.execute(111)
 
+    # 예외 없이 7단계까지 정상 실행됨
     openai.generate_briefing.assert_called_once()
     telegram.send_weekly_report.assert_called_once()
     mock_db.commit.assert_called_once()
 
 
+# ---------------------------------------------------------------------------
+# TC9: send_weekly_report 파라미터 검증
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_send_weekly_report_parameters(usecase, mock_dependencies):
+    """send_weekly_report에 올바른 chat_id, link_id, 메시지가 전달된다."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
     openai = mock_dependencies["openai"]

--- a/tests/test_weekly_report.py
+++ b/tests/test_weekly_report.py
@@ -1,16 +1,15 @@
-"""GenerateWeeklyReportUseCase 단위 테스트."""
-import pytest
+"""GenerateWeeklyReportUseCase unit tests."""
+
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from app.application.usecases.generate_weekly_report_usecase import (
     GenerateWeeklyReportUseCase,
+    _build_report_message,
 )
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 def _make_user(telegram_id: int) -> MagicMock:
     user = MagicMock()
@@ -38,10 +37,6 @@ def _make_candidate(
     }
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
 @pytest.fixture
 def mock_db() -> AsyncMock:
     db = AsyncMock()
@@ -67,13 +62,8 @@ def usecase(mock_dependencies) -> GenerateWeeklyReportUseCase:
     return GenerateWeeklyReportUseCase(**mock_dependencies)
 
 
-# ---------------------------------------------------------------------------
-# TC1: Happy Path — 7단계 순서대로 실행, db.commit() 1회
-# ---------------------------------------------------------------------------
-
 @pytest.mark.asyncio
 async def test_happy_path(usecase, mock_dependencies, mock_db):
-    """정상 흐름: 7단계 모두 실행, db.commit() 정확히 1회."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
     openai = mock_dependencies["openai"]
@@ -93,13 +83,8 @@ async def test_happy_path(usecase, mock_dependencies, mock_db):
     mock_db.commit.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
-# TC2: centroid 없음 → 조기 종료 (LLM/Telegram 미호출)
-# ---------------------------------------------------------------------------
-
 @pytest.mark.asyncio
 async def test_no_embeddings_early_return(usecase, mock_dependencies, mock_db):
-    """임베딩이 전혀 없으면 LLM·Telegram 호출 없이 조기 종료."""
     lr = mock_dependencies["link_repo"]
     openai = mock_dependencies["openai"]
     telegram = mock_dependencies["telegram"]
@@ -115,13 +100,8 @@ async def test_no_embeddings_early_return(usecase, mock_dependencies, mock_db):
     mock_db.commit.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# TC3: 재활성화 후보 없음 → 조기 종료
-# ---------------------------------------------------------------------------
-
 @pytest.mark.asyncio
 async def test_no_candidates_early_return(usecase, mock_dependencies, mock_db):
-    """재활성화 후보가 없으면 브리핑 생성·전송 미호출."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
     openai = mock_dependencies["openai"]
@@ -139,13 +119,8 @@ async def test_no_candidates_early_return(usecase, mock_dependencies, mock_db):
     mock_db.commit.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# TC4: execute_for_all_users — 3유저 → execute() 3회 호출
-# ---------------------------------------------------------------------------
-
 @pytest.mark.asyncio
 async def test_execute_for_all_users(usecase, mock_dependencies):
-    """전체 유저 3명에 대해 execute()가 각각 호출된다."""
     users = [_make_user(111), _make_user(222), _make_user(333)]
     mock_dependencies["user_repo"].get_all_users.return_value = users
 
@@ -157,13 +132,8 @@ async def test_execute_for_all_users(usecase, mock_dependencies):
     assert called_ids == [111, 222, 333]
 
 
-# ---------------------------------------------------------------------------
-# TC5: 에러 격리 — 222번 유저 실패 → rollback → 333번 계속 처리
-# ---------------------------------------------------------------------------
-
 @pytest.mark.asyncio
 async def test_error_isolation(usecase, mock_dependencies, mock_db):
-    """한 유저 실패 시 rollback 후 다음 유저 계속 처리."""
     users = [_make_user(111), _make_user(222), _make_user(333)]
     mock_dependencies["user_repo"].get_all_users.return_value = users
 
@@ -177,13 +147,8 @@ async def test_error_isolation(usecase, mock_dependencies, mock_db):
     mock_db.rollback.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
-# TC6: 중복 추천 방지 — excluded_ids 파라미터 검증
-# ---------------------------------------------------------------------------
-
 @pytest.mark.asyncio
 async def test_excluded_ids_passed_to_candidates(usecase, mock_dependencies):
-    """rec_repo에서 받은 excluded_ids가 get_reactivation_candidates에 전달된다."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
 
@@ -198,13 +163,8 @@ async def test_excluded_ids_passed_to_candidates(usecase, mock_dependencies):
     assert call_kwargs["excluded_ids"] == [10, 20]
 
 
-# ---------------------------------------------------------------------------
-# TC7: 최근 7일 임베딩 없을 때 전체 폴백
-# ---------------------------------------------------------------------------
-
 @pytest.mark.asyncio
 async def test_recent_embeddings_empty_uses_all_fallback(usecase, mock_dependencies):
-    """최근 7일 임베딩이 없으면 get_all_summary_embeddings 폴백을 호출한다."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
 
@@ -219,19 +179,13 @@ async def test_recent_embeddings_empty_uses_all_fallback(usecase, mock_dependenc
     lr.get_all_summary_embeddings.assert_called_once_with(111)
 
 
-# ---------------------------------------------------------------------------
-# TC8: drift 임계값 미달 처리 (current_cats < 3)
-# ---------------------------------------------------------------------------
-
 @pytest.mark.asyncio
 async def test_drift_skipped_when_few_categories(usecase, mock_dependencies, mock_db):
-    """최근 카테고리가 3개 미만이면 drift 계산 생략 후 정상 실행."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
     openai = mock_dependencies["openai"]
     telegram = mock_dependencies["telegram"]
 
-    # 최근 카테고리 2개 → drift 계산 건너뜀
     lr.get_categories_by_period.return_value = ["AI", "Dev"]
     lr.get_summary_embeddings_by_period.return_value = [[0.1, 0.2, 0.3]]
     rr.get_recently_recommended_link_ids.return_value = []
@@ -240,19 +194,13 @@ async def test_drift_skipped_when_few_categories(usecase, mock_dependencies, moc
 
     await usecase.execute(111)
 
-    # 예외 없이 7단계까지 정상 실행됨
     openai.generate_briefing.assert_called_once()
     telegram.send_weekly_report.assert_called_once()
     mock_db.commit.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
-# TC9: send_weekly_report 파라미터 검증
-# ---------------------------------------------------------------------------
-
 @pytest.mark.asyncio
 async def test_send_weekly_report_parameters(usecase, mock_dependencies):
-    """send_weekly_report에 올바른 chat_id, link_id, 메시지가 전달된다."""
     lr = mock_dependencies["link_repo"]
     rr = mock_dependencies["rec_repo"]
     openai = mock_dependencies["openai"]
@@ -273,3 +221,14 @@ async def test_send_weekly_report_parameters(usecase, mock_dependencies):
     assert call_kwargs["link_id"] == 42
     assert "이번 주 지식 리포트" in call_kwargs["text"]
     assert "이번 주 브리핑 텍스트" in call_kwargs["text"]
+
+
+def test_build_report_message_uses_well_formed_html_labels():
+    candidate = _make_candidate(title="중요한 링크", url="https://test.com")
+
+    message = _build_report_message("이번 주 브리핑 텍스트", candidate)
+
+    assert "<b>이번 주 지식 리포트</b>" in message
+    assert "<b>다시 보기 추천</b>" in message
+    assert "<b>중요한 링크</b>" in message
+    assert message.count("<b>") == message.count("</b>")

--- a/tests/test_weekly_report_catchup.py
+++ b/tests/test_weekly_report_catchup.py
@@ -1,15 +1,9 @@
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from app.application.usecases.generate_weekly_report_usecase import GenerateWeeklyReportUseCase
-
-
-def _make_user(telegram_id: int) -> MagicMock:
-    user = MagicMock()
-    user.telegram_id = telegram_id
-    return user
 
 
 @pytest.fixture
@@ -30,26 +24,24 @@ def catchup_usecase(catchup_dependencies) -> GenerateWeeklyReportUseCase:
 
 
 @pytest.mark.asyncio
-async def test_startup_catch_up_sends_only_users_missing_this_weeks_report(
+async def test_startup_catch_up_uses_single_query_for_users_missing_this_weeks_report(
     catchup_usecase,
     catchup_dependencies,
 ):
-    catchup_dependencies["user_repo"].get_all_users.return_value = [
-        _make_user(111),
-        _make_user(222),
-    ]
-    catchup_dependencies["rec_repo"].has_recommendation_since.side_effect = [False, True]
+    catchup_dependencies["rec_repo"].get_user_ids_without_recommendation_since.return_value = [111, 222]
 
     with patch.object(catchup_usecase, "execute", new=AsyncMock()) as mock_execute:
         await catchup_usecase.execute_startup_catch_up(
             now=datetime(2026, 3, 31, 1, 0, tzinfo=timezone.utc)
         )
 
-    catchup_dependencies["rec_repo"].has_recommendation_since.assert_any_await(
-        111,
-        datetime(2026, 3, 30, 0, 0, tzinfo=timezone.utc),
+    catchup_dependencies["rec_repo"].get_user_ids_without_recommendation_since.assert_awaited_once_with(
+        datetime(2026, 3, 30, 0, 0, tzinfo=timezone.utc)
     )
-    mock_execute.assert_awaited_once_with(111)
+    assert mock_execute.await_count == 2
+    mock_execute.assert_any_await(111)
+    mock_execute.assert_any_await(222)
+    catchup_dependencies["user_repo"].get_all_users.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -62,8 +54,7 @@ async def test_startup_catch_up_skips_before_monday_9am_kst(
             now=datetime(2026, 3, 29, 23, 59, tzinfo=timezone.utc)
         )
 
-    catchup_dependencies["user_repo"].get_all_users.assert_not_called()
-    catchup_dependencies["rec_repo"].has_recommendation_since.assert_not_called()
+    catchup_dependencies["rec_repo"].get_user_ids_without_recommendation_since.assert_not_called()
     mock_execute.assert_not_called()
 
 
@@ -72,11 +63,7 @@ async def test_startup_catch_up_rolls_back_and_continues_on_user_failure(
     catchup_usecase,
     catchup_dependencies,
 ):
-    catchup_dependencies["user_repo"].get_all_users.return_value = [
-        _make_user(111),
-        _make_user(222),
-    ]
-    catchup_dependencies["rec_repo"].has_recommendation_since.side_effect = [False, False]
+    catchup_dependencies["rec_repo"].get_user_ids_without_recommendation_since.return_value = [111, 222]
 
     async def _execute_side_effect(user_id: int) -> None:
         if user_id == 111:

--- a/tests/test_weekly_report_catchup.py
+++ b/tests/test_weekly_report_catchup.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.application.usecases.generate_weekly_report_usecase import GenerateWeeklyReportUseCase
+
+
+def _make_user(telegram_id: int) -> MagicMock:
+    user = MagicMock()
+    user.telegram_id = telegram_id
+    return user
+
+
+@pytest.fixture
+def catchup_dependencies() -> dict:
+    return {
+        "db": AsyncMock(),
+        "user_repo": AsyncMock(),
+        "link_repo": AsyncMock(),
+        "rec_repo": AsyncMock(),
+        "openai": AsyncMock(),
+        "telegram": AsyncMock(),
+    }
+
+
+@pytest.fixture
+def catchup_usecase(catchup_dependencies) -> GenerateWeeklyReportUseCase:
+    return GenerateWeeklyReportUseCase(**catchup_dependencies)
+
+
+@pytest.mark.asyncio
+async def test_startup_catch_up_sends_only_users_missing_this_weeks_report(
+    catchup_usecase,
+    catchup_dependencies,
+):
+    catchup_dependencies["user_repo"].get_all_users.return_value = [
+        _make_user(111),
+        _make_user(222),
+    ]
+    catchup_dependencies["rec_repo"].has_recommendation_since.side_effect = [False, True]
+
+    with patch.object(catchup_usecase, "execute", new=AsyncMock()) as mock_execute:
+        await catchup_usecase.execute_startup_catch_up(
+            now=datetime(2026, 3, 31, 1, 0, tzinfo=timezone.utc)
+        )
+
+    catchup_dependencies["rec_repo"].has_recommendation_since.assert_any_await(
+        111,
+        datetime(2026, 3, 30, 0, 0, tzinfo=timezone.utc),
+    )
+    mock_execute.assert_awaited_once_with(111)
+
+
+@pytest.mark.asyncio
+async def test_startup_catch_up_skips_before_monday_9am_kst(
+    catchup_usecase,
+    catchup_dependencies,
+):
+    with patch.object(catchup_usecase, "execute", new=AsyncMock()) as mock_execute:
+        await catchup_usecase.execute_startup_catch_up(
+            now=datetime(2026, 3, 29, 23, 59, tzinfo=timezone.utc)
+        )
+
+    catchup_dependencies["user_repo"].get_all_users.assert_not_called()
+    catchup_dependencies["rec_repo"].has_recommendation_since.assert_not_called()
+    mock_execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_catch_up_rolls_back_and_continues_on_user_failure(
+    catchup_usecase,
+    catchup_dependencies,
+):
+    catchup_dependencies["user_repo"].get_all_users.return_value = [
+        _make_user(111),
+        _make_user(222),
+    ]
+    catchup_dependencies["rec_repo"].has_recommendation_since.side_effect = [False, False]
+
+    async def _execute_side_effect(user_id: int) -> None:
+        if user_id == 111:
+            raise RuntimeError("catch-up failure")
+
+    with patch.object(catchup_usecase, "execute", new=AsyncMock(side_effect=_execute_side_effect)) as mock_execute:
+        await catchup_usecase.execute_startup_catch_up(
+            now=datetime(2026, 3, 31, 1, 0, tzinfo=timezone.utc)
+        )
+
+    assert mock_execute.await_count == 2
+    catchup_dependencies["db"].rollback.assert_awaited_once()


### PR DESCRIPTION
## 🎯 작업 개요
closed #118

## 📝 변경 사항
> 변경 사항을 간략하게 설명해주세요.

- 주간 리포트 메시지 빌더의 깨진 텍스트와 malformed HTML 구성을 정상화했습니다.
- Telegram HTML 모드 전송에 필요한 리포트 제목/구분선/추천 섹션 라벨을 안전한 문자열로 복구했습니다.
- 주간 리포트 payload가 정상 HTML 라벨을 유지하는지 회귀 테스트를 추가했습니다.

## ✅ 테스트 방법
> 이 PR을 로컬에서 테스트하려면 다음을 실행해주세요.
```bash
uvicorn app.main:app --reload --port 8000
pytest tests/test_weekly_report.py tests/test_telegram_client.py -q
```

> **필수 테스트**
- [x] `pytest tests/test_weekly_report.py tests/test_telegram_client.py -q`
- [x] `python -m compileall app/application/usecases/generate_weekly_report_usecase.py tests/test_weekly_report.py`
- [ ] 배포 환경에서 실제 스케줄러 실행 확인

## 📸 관련 이미지/스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 주간 리포트 메시지 포맷 수정 | 없음 |

## 💕 작업 상세 내용
- 현재 운영 컨테이너는 2026-04-02에 재시작된 상태라 지난 월요일 실행 로그는 남아 있지 않았습니다.
- DB 기준으로는 2026-03-30 09:00 KST 시점에 해당 유저가 리포트 대상이었고, 추천 후보도 충분했습니다.
- 그래서 이번 수정은 스킵 조건이 아니라 Telegram 전송 포맷 실패 가능성에 초점을 맞췄습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added startup catch-up that sends missed weekly reports at app start and KST-aware scheduling.

* **Style**
  * Updated weekly report header icon (📊 → 🧠), changed separator line, and revised brief push/commit wording in notifications.

* **Backend**
  * Introduced a check to determine whether a user already received a recommendation since a given time.

* **Tests**
  * Added tests for report HTML formatting and for the startup catch-up control flow and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->